### PR TITLE
Revision to return rounded value for ImageBytes.GetAverageValue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ You are welcome to use/update this software under the terms of the **MIT license
 A published package is available for download on [NuGet.org](https://www.nuget.org/packages/Freedom35.ImageProcessing).  
 |Version|Notes|
 |:---:|-----|
+|[1.0.2](https://www.nuget.org/packages/Freedom35.ImageProcessing/1.0.2)|Revision to return rounded value for ImageBytes.GetAverageValue.|
 |[1.0.1](https://www.nuget.org/packages/Freedom35.ImageProcessing/1.0.1)|Revision to add enum description attribute for 'Mexican Hat' smoothing filter.|
 |[1.0.0](https://www.nuget.org/packages/Freedom35.ImageProcessing/1.0.0)|Initial release.|
 

--- a/src/Freedom35.ImageProcessing/Freedom35.ImageProcessing.csproj
+++ b/src/Freedom35.ImageProcessing/Freedom35.ImageProcessing.csproj
@@ -16,7 +16,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>icon.png</PackageIcon>
     <UserSecretsId>57c09de8-df1f-4ca3-8302-0928eb86934b</UserSecretsId>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Freedom35.ImageProcessing/ImageBytes.cs
+++ b/src/Freedom35.ImageProcessing/ImageBytes.cs
@@ -343,7 +343,7 @@ namespace Freedom35.ImageProcessing
             }
 
             // Return average value within range
-            return count > 0 ? (byte)(sum / count) : byte.MinValue;
+            return count > 0 ? (byte)Math.Round(Convert.ToDouble(sum) / count) : byte.MinValue;
         }
 
         /// <summary>

--- a/tests/Freedom35.ImageProcessing.Tests/Freedom35.ImageProcessing.Tests.csproj
+++ b/tests/Freedom35.ImageProcessing.Tests/Freedom35.ImageProcessing.Tests.csproj
@@ -14,6 +14,8 @@
     <Copyright>Copyright © Alan Barr</Copyright>
 
     <RepositoryUrl>https://github.com/freedom35/image-processing</RepositoryUrl>
+
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Freedom35.ImageProcessing.Tests/TestImageBytes.cs
+++ b/tests/Freedom35.ImageProcessing.Tests/TestImageBytes.cs
@@ -129,7 +129,7 @@ namespace ImageProcessingTests
             byte avg = ImageBytes.GetAverageValue(image);
 
             // Average for image
-            Assert.AreEqual(0x8c, avg);
+            Assert.AreEqual(0x8d, avg);
 
             avg = ImageBytes.GetAverageValue(image, 0x22, 0x24);
 


### PR DESCRIPTION
Rounding the value before casting to byte for (slightly more) accuracy.