### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-windows.yml
+++ b/.github/workflows/dotnet-windows.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 env:
   solution: 'Freedom35.ImageProcessing.sln'
   build_config: 'Release'


### PR DESCRIPTION
Potential fix for [https://github.com/freedom35/image-processing/security/code-scanning/2](https://github.com/freedom35/image-processing/security/code-scanning/2)

To fix this, add an explicit `permissions` block in `.github/workflows/dotnet-windows.yml` so the `GITHUB_TOKEN` is scoped to least privilege.  
For this workflow, the best single fix is to set workflow-level permissions to:

- `contents: read`

This preserves existing behavior (checkout/build/test) while preventing accidental write-capable token inheritance if repo/org defaults are broader now or in the future.

**Where to change:**  
In `.github/workflows/dotnet-windows.yml`, insert a top-level `permissions:` section after the `on:` trigger block (or before `jobs:`). No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
